### PR TITLE
fix #961

### DIFF
--- a/go/logic/inspect.go
+++ b/go/logic/inspect.go
@@ -528,7 +528,7 @@ func (this *Inspector) CountTableRows() error {
 
 	this.migrationContext.Log.Infof("As instructed, I'm issuing a SELECT COUNT(*) on the table. This may take a while")
 
-	query := fmt.Sprintf(`select /* gh-ost */ count(*) as rows from %s.%s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
+	query := fmt.Sprintf(`select /* gh-ost */ count(*) as 'rows' from %s.%s`, sql.EscapeName(this.migrationContext.DatabaseName), sql.EscapeName(this.migrationContext.OriginalTableName))
 	var rowsEstimate int64
 	if err := this.db.QueryRow(query).Scan(&rowsEstimate); err != nil {
 		return err


### PR DESCRIPTION
fix https://github.com/github/gh-ost/issues/961

## A Pull Request should be associated with an Issue.

> We wish to have discussions in Issues. A single issue may be targeted by multiple PRs.
> If you're offering a new feature or fixing anything, we'd like to know beforehand in Issues,
> and potentially we'll be able to point development in a particular direction.

Related issue: https://github.com/github/gh-ost/issues/0123456789

> Further notes in https://github.com/github/gh-ost/blob/master/.github/CONTRIBUTING.md
> Thank you! We are open to PRs, but please understand if for technical reasons we are unable to accept each and any PR

### Description

https://dev.mysql.com/doc/refman/8.0/en/keywords.html
ROWS (R); became reserved in 8.0.2

if we use `-exact-rowcount` option, gh-ost will execute query
```
select /* gh-ost */ count(*) as rows from `db`.`t1`;
```
which will cause
```
You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'rows from `db`.`t1`' at line 1
```
Please use `\``
```
select /* gh-ost */ count(*) as `rows` from `db`.`t1`;
```

> In case this PR introduced Go code changes:

- [ ] contributed code is using same conventions as original code
- [ ] `script/cibuild` returns with no formatting errors, build errors or unit test errors.
